### PR TITLE
support custom library name

### DIFF
--- a/native_toolchain_rust/lib/src/builder.dart
+++ b/native_toolchain_rust/lib/src/builder.dart
@@ -3,12 +3,11 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:native_assets_cli/native_assets_cli.dart';
 import 'package:native_toolchain_rust/rustup.dart';
-import 'package:native_toolchain_rust_common/native_toolchain_rust_common.dart';
-import 'package:rustup/rustup.dart';
 import 'package:native_toolchain_rust/src/android_environment.dart';
 import 'package:native_toolchain_rust/src/crate_manifest.dart';
-
+import 'package:native_toolchain_rust_common/native_toolchain_rust_common.dart';
 import 'package:path/path.dart' as path;
+import 'package:rustup/rustup.dart';
 
 class RustToolchainException implements Exception {
   RustToolchainException({required this.message});
@@ -157,7 +156,7 @@ class RustBuilder {
         buildConfig.outputDirectory.resolve('native_toolchain_rust/');
 
     final dylibName =
-        buildConfig.targetOS.dylibFileName(manifestInfo.packageName);
+        buildConfig.targetOS.dylibFileName(manifestInfo.libraryName);
 
     if (buildConfig.dryRun) {
       output.addAsset(NativeCodeAsset(

--- a/native_toolchain_rust/lib/src/crate_manifest.dart
+++ b/native_toolchain_rust/lib/src/crate_manifest.dart
@@ -19,9 +19,10 @@ class ManifestException {
 }
 
 class CrateManifestInfo {
-  CrateManifestInfo({required this.packageName});
+  CrateManifestInfo({required this.packageName, required this.libraryName});
 
   final String packageName;
+  final String libraryName;
 
   static CrateManifestInfo parseManifest(String manifest,
       {final String? fileName}) {
@@ -34,7 +35,15 @@ class CrateManifestInfo {
     if (name == null) {
       throw ManifestException('Missing package name', fileName: fileName);
     }
-    return CrateManifestInfo(packageName: name);
+
+    final lib = toml.toMap()['lib'];
+    if (lib == null) {
+      throw ManifestException('Missing library section', fileName: fileName);
+    }
+
+    final libName = (lib['name'] ?? name).replaceAll("-", "_");
+
+    return CrateManifestInfo(packageName: name, libraryName: libName);
   }
 
   static CrateManifestInfo load(Uri manifestPath) {


### PR DESCRIPTION
My crate has a dash in the name. Rust libraries can't have dashes.