### PR TITLE
fix: Removed caret syntax from asset_cli package

### DIFF
--- a/example/flutter_package/example/pubspec.lock
+++ b/example/flutter_package/example/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -280,7 +280,7 @@ packages:
       path: "../../../native_toolchain_rust"
       relative: true
     source: path
-    version: "0.1.0-dev.7"
+    version: "0.1.0-dev.8"
   native_toolchain_rust_common:
     dependency: "direct overridden"
     description:
@@ -358,7 +358,7 @@ packages:
       path: "../../../rustup"
       relative: true
     source: path
-    version: "0.1.0-dev.6"
+    version: "0.1.0-dev.7"
   shelf:
     dependency: transitive
     description:
@@ -440,10 +440,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -456,26 +456,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.4"
   toml:
     dependency: transitive
     description:
@@ -504,10 +504,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:

--- a/native_doctor/pubspec.lock
+++ b/native_doctor/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_assets_cli
-      sha256: "3da9bdd4beb2ed059dae7fd93baa62c5f6c3cdf630bbb88334303dfa92d6da26"
+      sha256: "1ff032c0ca050391c4c5107485f1a26e0e95cee18d1fdb2b7bdbb990efd3c188"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   native_toolchain_rust_common:
     dependency: "direct main"
     description:
@@ -286,7 +286,7 @@ packages:
       path: "../rustup"
       relative: true
     source: path
-    version: "0.1.0-dev.6"
+    version: "0.1.0-dev.7"
   shelf:
     dependency: transitive
     description:
@@ -379,26 +379,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d72b538180efcf8413cd2e4e6fcc7ae99c7712e0909eb9223f9da6e6d0ef715f
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.4"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.8"
   typed_data:
     dependency: transitive
     description:
@@ -456,4 +456,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0-265.0.dev <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/native_doctor/pubspec.yaml
+++ b/native_doctor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_doctor
 description: A tool that analyzes Flutter and Dart project dependencies, find requirements for native toolchains and, if possible, resolves issues.
-version: 0.1.0-dev.4
+version: 0.1.0-dev.5
 repository: https://github.com/irondash/native_toolchain_rust
 
 environment:
@@ -18,7 +18,7 @@ dependencies:
   pub_semver: ^2.1.4
   yaml: ^3.1.2
   pubspec_parse: ^1.2.3
-  native_assets_cli: ^0.7.2
+  native_assets_cli: ">=0.7.2 <1.0.0"
   collection: ^1.18.0
   logging: ^1.2.0
   path: ^1.9.0

--- a/native_toolchain_rust/pubspec.lock
+++ b/native_toolchain_rust/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: "../rustup"
       relative: true
     source: path
-    version: "0.1.0-dev.6"
+    version: "0.1.0-dev.7"
   shelf:
     dependency: transitive
     description:

--- a/native_toolchain_rust/pubspec.yaml
+++ b/native_toolchain_rust/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_toolchain_rust
 description: Library to interact with rustup and cargo when building Dart and Flutter native assets written in Rust.
-version: 0.1.0-dev.7
+version: 0.1.0-dev.8
 homepage: https://github.com/irondash/native_toolchain_rust.git
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   native_toolchain_rust_common: ^0.1.0-dev.3
   collection: ^1.18.0
   logging: ^1.2.0
-  native_assets_cli: ^0.7.2
+  native_assets_cli: ">=0.7.2 <1.0.0"
   path: ^1.9.0
   process: ^5.0.2
   pub_semver: ^2.1.4

--- a/rustup/pubspec.yaml
+++ b/rustup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rustup
 description: "Dart bindings for the rustup CLI tool."
-version: 0.1.0-dev.6
+version: 0.1.0-dev.7
 homepage: https://github.com/irondash/native_toolchain_rust.git
 
 environment:
@@ -10,7 +10,7 @@ dependencies:
   native_toolchain_rust_common: ^0.1.0-dev.3
   process: ^5.0.2
   pub_semver: ^2.1.4
-  native_assets_cli: ^0.7.2
+  native_assets_cli: ">=0.7.2 <1.0.0"
   http: ^1.2.1
   logging: ^1.2.0
   path: ^1.9.0


### PR DESCRIPTION
Hello everyone!

For reverse compatibility need remove caret syntax I think it's good not to often update the package.

About it [here](https://dart.dev/tools/pub/dependencies#caret-syntax)